### PR TITLE
Add ablation examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,6 @@ which may require different parts of the Nengo ecosystem
 (e.g., the Nengo GUI),
 different external packages
 (e.g., the Jupyter notebook)
-and maybe licensed differently.
+and may be licensed differently.
 Please see the README in each folder for more information
 on how to run those specific examples.

--- a/ablate/README.rst
+++ b/ablate/README.rst
@@ -1,0 +1,63 @@
+****************
+Ablating neurons
+****************
+
+The Jupyter notebooks in this directory
+emulate the ablation of neurons
+by setting the encoders of those neurons to 0,
+and setting the bias of those neurons to a large negative number.
+
+The function of interest is::
+
+    def ablate_ensemble(ens, proportion, sim, bias=True):
+        """Ablate a proportion of the neurons in an ensemble.
+
+        The ablation is done by setting the encoder and gain associated
+        with a neuron to zero. Since no input current being injected,
+        the neuron will generally be silent. However, if there is direct
+        current injected with a neuron-to-neuron connection, then the
+        cell may still fire. To counter that in most cases, we set the
+        bias associated with the neuron to a large negative value.
+        """
+
+        n_neurons = min(int(ens.n_neurons * proportion), ens.n_neurons)
+        idx = np.random.choice(np.arange(ens.n_neurons), replace=False, size=n_neurons)
+
+        encoder_sig = sim.signals[sim.model.sig[ens]['encoders']]
+        encoder_sig.setflags(write=True)
+        encoder_sig[idx] = 0.0
+        encoder_sig.setflags(write=False)
+
+        if bias:
+            bias_sig = sim.signals[sim.model.sig[ens.neurons]['bias']]
+            bias_sig.setflags(write=True)
+            bias_sig[idx] = -1000
+
+The notebooks in this directory show how this can be applied
+in a simple model (``ablate_ensemble.py``)
+and a more complicated SPA model (``ablate_spa.py``).
+
+Requirements
+============
+
+You will need Python installed with the following packages:
+
+- `jupyter <http://jupyter.readthedocs.io/en/latest/install.html>`_
+- `nengo>=2.3.0 <http://pythonhosted.org/nengo/getting_started.html#installation>`_
+
+Usage
+=====
+
+To run these notebooks,
+`start the Jupyter notebook <http://jupyter.readthedocs.io/en/latest/running.html>`_
+and navigate to this directory.
+Click on the ``.ipynb`` file you wish to run.
+
+License
+=======
+
+This example is copyright Applied Brain Research
+and is licensed with the
+`Nengo license <http://pythonhosted.org/nengo/license.html>`_,
+which permits using, copying, sharing, and making derivative works
+for any non-commercial purpose.

--- a/ablate/ablate_ensemble.ipynb
+++ b/ablate/ablate_ensemble.ipynb
@@ -1,0 +1,622 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ablating neurons in an ensemble\n",
+    "\n",
+    "The model used here is a simple controlled integrator,\n",
+    "as is shown in\n",
+    "[this core Nengo example](http://pythonhosted.org/nengo/examples/controlled_integrator.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "\n",
+    "import nengo\n",
+    "%load_ext nengo.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from nengo.utils.functions import piecewise\n",
+    "\n",
+    "with nengo.Network(label='Controlled Integrator') as model:\n",
+    "    input_func = piecewise({0: 0, 0.2: 5, 0.3: 0, 0.44: -10, 0.54: 0, 0.8: 5, 0.9: 0})\n",
+    "    control_func = piecewise({0: 1, 0.6: 0.5})\n",
+    "\n",
+    "    tau = 0.1\n",
+    "\n",
+    "    stim = nengo.Node(input_func)\n",
+    "    control = nengo.Node(output=control_func)\n",
+    "    ens = nengo.Ensemble(225, dimensions=2, radius=1.5)\n",
+    "    nengo.Connection(stim, ens, transform=[[tau], [0]], synapse=tau)\n",
+    "    nengo.Connection(control, ens[1])\n",
+    "\n",
+    "\n",
+    "    nengo.Connection(ens, ens[0],\n",
+    "                     function=lambda x: x[0] * x[1],\n",
+    "                     synapse=tau)\n",
+    "\n",
+    "    ens_probe = nengo.Probe(ens, synapse=0.01)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "with nengo.Simulator(model) as sim:\n",
+    "    sim.run(1.4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def plot():\n",
+    "    t = sim.trange()\n",
+    "    dt = t[1] - t[0]\n",
+    "    input_sig = list(map(input_func, t))\n",
+    "    control_sig = list(map(control_func, t))\n",
+    "    ref = dt * np.cumsum(input_sig)\n",
+    "\n",
+    "    plt.figure(figsize=(6, 8))\n",
+    "    plt.subplot(2, 1, 1)\n",
+    "    plt.plot(t, input_sig, label='Input')\n",
+    "    plt.xlim(right=t[-1])\n",
+    "    plt.ylim(-11, 11)\n",
+    "    plt.ylabel('Input')\n",
+    "    plt.legend(loc=\"lower left\", frameon=False)\n",
+    "\n",
+    "    plt.subplot(2, 1, 2)\n",
+    "    plt.plot(t, ref, 'k--', label='Exact')\n",
+    "    plt.plot(t, sim.data[ens_probe][:,0], label='A (value)')\n",
+    "    plt.plot(t, sim.data[ens_probe][:,1], label='A (control)')\n",
+    "    plt.xlim(right=t[-1])\n",
+    "    plt.ylim(-1.1, 1.1)\n",
+    "    plt.xlabel('Time (s)')\n",
+    "    plt.ylabel('x(t)')\n",
+    "    plt.legend(loc=\"lower left\", frameon=False)\n",
+    "plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The model is composed primarily of a single two-dimensional ensemble.\n",
+    "The first dimension takes in input;\n",
+    "the second dimension is a control signal.\n",
+    "The ensemble is recurrently connected such that\n",
+    "the ensemble integrates the input signal\n",
+    "in its first dimension,\n",
+    "as long as the control dimension is near 1.\n",
+    "As can be seen above, it performs as expected."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can emulate the effects of ablating neurons in an ensemble\n",
+    "(or, equivalently, the input connections to those neurons)\n",
+    "by setting the encoder associated with them to 0.\n",
+    "If we wish to fully ablate the neurons\n",
+    "and silence them entirely,\n",
+    "we can inject a constant negative current into them.\n",
+    "We'll make a helper function so that we can do this\n",
+    "for any ensemble."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def ablate_ensemble(ens, proportion, sim, bias=True):\n",
+    "    \"\"\"Ablate a proportion of the neurons in an ensemble.\n",
+    "\n",
+    "    The ablation is done by setting the encoder and gain associated\n",
+    "    with a neuron to zero. Since no input current being injected,\n",
+    "    the neuron will generally be silent. However, if there is direct\n",
+    "    current injected with a neuron-to-neuron connection, then the\n",
+    "    cell may still fire. To counter that in most cases, we set the\n",
+    "    bias associated with the neuron to a large negative value.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    n_neurons = min(int(ens.n_neurons * proportion), ens.n_neurons)\n",
+    "    idx = np.random.choice(np.arange(ens.n_neurons), replace=False, size=n_neurons)\n",
+    "\n",
+    "    encoder_sig = sim.signals[sim.model.sig[ens]['encoders']]\n",
+    "    encoder_sig.setflags(write=True)\n",
+    "    encoder_sig[idx] = 0.0\n",
+    "    encoder_sig.setflags(write=False)\n",
+    "\n",
+    "    if bias:\n",
+    "        bias_sig = sim.signals[sim.model.sig[ens.neurons]['bias']]\n",
+    "        bias_sig.setflags(write=True)\n",
+    "        bias_sig[idx] = -1000"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that this function requires a built `Simulator`.\n",
+    "This is because decoders are determined during\n",
+    "the build process, and do not exist when the model\n",
+    "is originally specified.\n",
+    "\n",
+    "Let's see the effects of ablating 1% of the 225 neurons\n",
+    "in the ensemble."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "with nengo.Simulator(model) as sim:\n",
+    "    ablate_ensemble(ens, 0.01, sim)\n",
+    "    sim.run(1.4)\n",
+    "plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Not much happened. Let's bump this up to 10% of the 225 neurons."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "with nengo.Simulator(model) as sim:\n",
+    "    ablate_ensemble(ens, 0.1, sim)\n",
+    "    sim.run(1.4)\n",
+    "plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Still not bad, but getting worse. How about 25%?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "with nengo.Simulator(model) as sim:\n",
+    "    ablate_ensemble(ens, 0.25, sim)\n",
+    "    sim.run(1.4)\n",
+    "plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To verify that this is indeed working as expected,\n",
+    "we can ablate all of the neurons and confirm that\n",
+    "there is no activity in the ensemble."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "with nengo.Simulator(model) as sim:\n",
+    "    ablate_ensemble(ens, 1.0, sim)\n",
+    "    sim.run(1.4)\n",
+    "plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we remove the negative bias current,\n",
+    "we can see that the neurons still have background activity,\n",
+    "but do not respond to input."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "with nengo.Simulator(model) as sim:\n",
+    "    ablate_ensemble(ens, 1.0, sim, bias=False)\n",
+    "    sim.run(1.4)\n",
+    "plot()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  },
+  "widgets": {
+   "state": {
+    "0132386e12fe4fb8a06dfb36057dfff2": {
+     "views": []
+    },
+    "01b509b58e0c43268985c02b6f917f55": {
+     "views": []
+    },
+    "024f20e662c64f68890a529db82350d5": {
+     "views": []
+    },
+    "07773b3ab7624702abfa0300da154a7b": {
+     "views": [
+      {
+       "cell_index": 13
+      }
+     ]
+    },
+    "09556ef964d240a891d156f5d698dfc6": {
+     "views": []
+    },
+    "0b88dc0dd3cb41bc92eb6346399749f2": {
+     "views": [
+      {
+       "cell_index": 9
+      }
+     ]
+    },
+    "0c6ebbb2d44a4d7c8cde28e44d0fdd82": {
+     "views": [
+      {
+       "cell_index": 9
+      }
+     ]
+    },
+    "0ed3c5a16d734b41be94a9a6f3d29ab9": {
+     "views": [
+      {
+       "cell_index": 11
+      }
+     ]
+    },
+    "15612c25342649b1a5d3efefcadfcfa9": {
+     "views": []
+    },
+    "170712c4783349db831bc818592d1e18": {
+     "views": []
+    },
+    "297cb3f1e28e492fa26a20f13fb7b8d8": {
+     "views": []
+    },
+    "29968f61b9684f6d86a39d86f7a7b6e6": {
+     "views": []
+    },
+    "2c044758366343b091d3576ca92fe38c": {
+     "views": []
+    },
+    "2d8fd54f06614d76b3fff013e56bcb6a": {
+     "views": []
+    },
+    "2fd2c4d89f364143a0de5946b000ea55": {
+     "views": []
+    },
+    "3102c2f7d9ae47fcaafce1b62353794c": {
+     "views": [
+      {
+       "cell_index": 9
+      }
+     ]
+    },
+    "35109ee1d3104936a8a626887c2678ca": {
+     "views": [
+      {
+       "cell_index": 13
+      }
+     ]
+    },
+    "36880db395c741169560456766361b55": {
+     "views": []
+    },
+    "36e2e3038c1f4de4b9294dfcd231031a": {
+     "views": [
+      {
+       "cell_index": 17
+      }
+     ]
+    },
+    "3c4092f51798490caadfaa89e7b6d4cd": {
+     "views": []
+    },
+    "4f90307d25cc443cb7b9292715cb5884": {
+     "views": [
+      {
+       "cell_index": 17
+      }
+     ]
+    },
+    "5231fca38d1f493fbd19777d22c4f8d2": {
+     "views": []
+    },
+    "52dfe0466dc54224ac7975e07f712d1c": {
+     "views": [
+      {
+       "cell_index": 3
+      }
+     ]
+    },
+    "53af916f99354835ac0901ff248ce71a": {
+     "views": []
+    },
+    "5796f25ae2f44d02be4a84f6dc9f64b3": {
+     "views": []
+    },
+    "58d5d031e2fd44e284dc7d95e3ed7c49": {
+     "views": []
+    },
+    "5c74a9f623714ddd94571248019d5daf": {
+     "views": [
+      {
+       "cell_index": 9
+      }
+     ]
+    },
+    "5ebc646f0e594243b6b95ebc1e637897": {
+     "views": []
+    },
+    "5fb7d1e40deb4e5a824212ab0fc17bf1": {
+     "views": [
+      {
+       "cell_index": 13
+      }
+     ]
+    },
+    "6438c32fea944dbabd8adfa0ce2aabb4": {
+     "views": []
+    },
+    "64cd11098d2d45f2b530a1734fc46b5e": {
+     "views": []
+    },
+    "6508973d58f64d9190d581a455afcabf": {
+     "views": []
+    },
+    "6dc9b81d25b949f18e7ddffb9906424d": {
+     "views": []
+    },
+    "73cd3dfaf6074254bd371e27b539d3fe": {
+     "views": [
+      {
+       "cell_index": 15
+      }
+     ]
+    },
+    "7bb2d37354354d65b02c9e3e9c651647": {
+     "views": []
+    },
+    "7d3c0c8a6bcd4dfeacbc54bb7c6f85ed": {
+     "views": [
+      {
+       "cell_index": 3
+      }
+     ]
+    },
+    "7e3591d7f98a4a7da8cd2c6a17002d15": {
+     "views": []
+    },
+    "82c0e0526b9843108a2e5a82ff0613f9": {
+     "views": []
+    },
+    "8319c94e145648259db9e5a69283c0b3": {
+     "views": []
+    },
+    "8a06b559a93f42ff88755fcf16f42be3": {
+     "views": []
+    },
+    "9490c281b2b047618bb4b43666b867d7": {
+     "views": []
+    },
+    "977afbe3b3874be18ccead6b5de94894": {
+     "views": []
+    },
+    "9bd20272a72745cf80e1aaea223845ae": {
+     "views": []
+    },
+    "9c6f8de1066c4560ae0338f2a6b7a81a": {
+     "views": [
+      {
+       "cell_index": 13
+      }
+     ]
+    },
+    "9d6dd299741145a8b07fe99c3c5f0e36": {
+     "views": []
+    },
+    "9eeea4fc92f84754be27ef3fe8983ae2": {
+     "views": [
+      {
+       "cell_index": 15
+      }
+     ]
+    },
+    "a0203908050e42368e7f005a680bda7d": {
+     "views": [
+      {
+       "cell_index": 15
+      }
+     ]
+    },
+    "a57eccc5a3e044a6af90fae6c4428617": {
+     "views": [
+      {
+       "cell_index": 15
+      }
+     ]
+    },
+    "ac92b91d0c0c4125af4b9cb08fe165c3": {
+     "views": []
+    },
+    "b5236806912e47f496372dd305b9c16f": {
+     "views": [
+      {
+       "cell_index": 11
+      }
+     ]
+    },
+    "b7225e6796744296a114c742a4d11613": {
+     "views": []
+    },
+    "ba8e6bea218d424ab7748eef4af85c1b": {
+     "views": []
+    },
+    "c27c6bd9d77d496c9b3f1a84cb2a9ed5": {
+     "views": []
+    },
+    "c5a38416082545d79435d95c941e7491": {
+     "views": []
+    },
+    "c9f4abf34aa044eb92ba7f81f8e4038b": {
+     "views": []
+    },
+    "cb4ab9ce34b643c9844c7b8c6a84f0d7": {
+     "views": []
+    },
+    "ce9da041f6c44ccd8f9cbae499e200af": {
+     "views": [
+      {
+       "cell_index": 11
+      }
+     ]
+    },
+    "d0a2d3b1b2084142a29b62c2992f425c": {
+     "views": [
+      {
+       "cell_index": 13
+      }
+     ]
+    },
+    "d0fecee0d4e04c90b30561a84aaf0bb2": {
+     "views": []
+    },
+    "d4a25dba94b64db0bfa5a3d787f2dc28": {
+     "views": [
+      {
+       "cell_index": 13
+      }
+     ]
+    },
+    "da5ba4768d61491fb09c1cb90b1fa432": {
+     "views": []
+    },
+    "dae8857db8784c4a8adbb4679cecdb49": {
+     "views": []
+    },
+    "dd488e3dac0f4bc7b8c4336f642b1407": {
+     "views": []
+    },
+    "ddd0ed1a24e64d4d9fc17c5c51247d69": {
+     "views": [
+      {
+       "cell_index": 13
+      }
+     ]
+    },
+    "e04ad5abbac74225a5848b91a13c7f99": {
+     "views": []
+    },
+    "e08ea6d28d434280b0c8f47c33303845": {
+     "views": [
+      {
+       "cell_index": 13
+      }
+     ]
+    },
+    "e5454178f8cd42e1b1dcf115cbdfd4e8": {
+     "views": []
+    },
+    "e6ecc7ecb6984676b3c2d412095e43eb": {
+     "views": []
+    },
+    "ee2fcc08a6d1483cad7e043331833fa4": {
+     "views": [
+      {
+       "cell_index": 13
+      }
+     ]
+    },
+    "f5b04399053a4b8eaf4f8900480d8f59": {
+     "views": []
+    },
+    "f803ee4799a34dbd96e6aa473748e519": {
+     "views": []
+    },
+    "f9d211e425284857bb374ff502771313": {
+     "views": []
+    }
+   },
+   "version": "1.1.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/ablate/ablate_spa.ipynb
+++ b/ablate/ablate_spa.ipynb
@@ -1,0 +1,620 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ablating neurons in a SPA model\n",
+    "\n",
+    "The model used here is a SPA model that goes through\n",
+    "a set sequence of semantic pointers,\n",
+    "as shown in\n",
+    "[this core Nengo example](http://pythonhosted.org/nengo/examples/controlled_integrator.html).\n",
+    "\n",
+    "This is primarily a demonstration of how to apply the `ablate_ensemble` function\n",
+    "to all the ensembles in a network or SPA module.\n",
+    "If you haven't gone through the `ablate_ensemble` example\n",
+    "in this directory, go through that example first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "\n",
+    "import nengo\n",
+    "%load_ext nengo.ipynb\n",
+    "from nengo import spa"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dimensions = 16\n",
+    "\n",
+    "def start(t):\n",
+    "    if t < 0.05:\n",
+    "        return 'A'\n",
+    "    else:\n",
+    "        return '0'\n",
+    "\n",
+    "with spa.SPA() as model:\n",
+    "    model.cortex = spa.Buffer(dimensions=dimensions)\n",
+    "    actions = spa.Actions(\n",
+    "        'dot(cortex, A) --> cortex = B',\n",
+    "        'dot(cortex, B) --> cortex = C',\n",
+    "        'dot(cortex, C) --> cortex = D',\n",
+    "        'dot(cortex, D) --> cortex = E',\n",
+    "        'dot(cortex, E) --> cortex = A'\n",
+    "    )\n",
+    "    model.bg = spa.BasalGanglia(actions=actions)\n",
+    "    model.thal = spa.Thalamus(model.bg)\n",
+    "    model.input = spa.Input(cortex=start)\n",
+    "\n",
+    "    cortex = nengo.Probe(model.cortex.state.output, synapse=0.01)\n",
+    "    actions = nengo.Probe(model.thal.actions.output, synapse=0.01)\n",
+    "    utility = nengo.Probe(model.bg.input, synapse=0.01)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "with nengo.Simulator(model) as sim:\n",
+    "    sim.run(0.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def plot():\n",
+    "    fig = plt.figure(figsize=(12,8))\n",
+    "    p1 = fig.add_subplot(3,1,1)\n",
+    "\n",
+    "    p1.plot(sim.trange(), model.similarity(sim.data, cortex))\n",
+    "    p1.legend(model.get_output_vocab('cortex').keys, fontsize='x-small')\n",
+    "    p1.set_ylabel('State')\n",
+    "\n",
+    "    p2 = fig.add_subplot(3,1,2)\n",
+    "    p2.plot(sim.trange(), sim.data[actions])\n",
+    "    p2_legend_txt = [a.effect for a in model.bg.actions.actions]\n",
+    "    p2.legend(p2_legend_txt, fontsize='x-small')\n",
+    "    p2.set_ylabel('Action')\n",
+    "\n",
+    "    p3 = fig.add_subplot(3,1,3)\n",
+    "    p3.plot(sim.trange(), sim.data[utility])\n",
+    "    p3_legend_txt = [a.condition for a in model.bg.actions.actions]\n",
+    "    p3.legend(p3_legend_txt, fontsize='x-small')\n",
+    "    p3.set_ylabel('Utility')\n",
+    "\n",
+    "    fig.subplots_adjust(hspace=0.2)\n",
+    "plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will use the same `ablate_ensemble` function as before."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def ablate_ensemble(ens, proportion, sim, bias=True):\n",
+    "    \"\"\"Ablate a proportion of the neurons in an ensemble.\n",
+    "\n",
+    "    The ablation is done by setting the encoder and gain associated\n",
+    "    with a neuron to zero. Since no input current being injected,\n",
+    "    the neuron will generally be silent. However, if there is direct\n",
+    "    current injected with a neuron-to-neuron connection, then the\n",
+    "    cell may still fire. To counter that in most cases, we set the\n",
+    "    bias associated with the neuron to a large negative value.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    n_neurons = min(int(ens.n_neurons * proportion), ens.n_neurons)\n",
+    "    idx = np.random.choice(np.arange(ens.n_neurons), replace=False, size=n_neurons)\n",
+    "\n",
+    "    encoder_sig = sim.signals[sim.model.sig[ens]['encoders']]\n",
+    "    encoder_sig.setflags(write=True)\n",
+    "    encoder_sig[idx] = 0.0\n",
+    "    encoder_sig.setflags(write=False)\n",
+    "\n",
+    "    if bias:\n",
+    "        bias_sig = sim.signals[sim.model.sig[ens.neurons]['bias']]\n",
+    "        bias_sig.setflags(write=True)\n",
+    "        bias_sig[idx] = -1000"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This time, however, instead of applying it to a single ensemble,\n",
+    "we will apply it to all of the ensembles in a SPA module.\n",
+    "\n",
+    "We can therefore see the effects of ablation in different\n",
+    "parts of the model. Let's see what happens when ablating\n",
+    "25% of the neurons in the cortex."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "with nengo.Simulator(model) as sim:\n",
+    "    for ens in model.cortex.all_ensembles:\n",
+    "        ablate_ensemble(ens, 0.25, sim)\n",
+    "    sim.run(0.5)\n",
+    "plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In some cases, the sequence stops after some time, which is interesting!\n",
+    "\n",
+    "It saves us a tiny bit of typing to make a helper function\n",
+    "to ablate whole networks (or SPA modules).\n",
+    "So let's do that, then look at the effects of ablating\n",
+    "the other parts of the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def ablate_network(net, proportion, sim, bias=True):\n",
+    "    \"\"\"Ablate a proportion of the neurons in all ensembles in a network.\"\"\"\n",
+    "    for ens in net.all_ensembles:\n",
+    "        ablate_ensemble(ens, proportion, sim, bias=bias)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "with nengo.Simulator(model) as sim:\n",
+    "    ablate_network(model.bg, 0.25, sim)\n",
+    "    sim.run(0.5)\n",
+    "plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "with nengo.Simulator(model) as sim:\n",
+    "    ablate_network(model.thal, 0.25, sim)\n",
+    "    sim.run(0.5)\n",
+    "plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, let's look at what happens when we ablate\n",
+    "25% of the neurons in the entire model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "with nengo.Simulator(model) as sim:\n",
+    "    ablate_network(model, 0.25, sim)\n",
+    "    sim.run(0.5)\n",
+    "plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Not silencing the neurons seems to hurt performance,\n",
+    "possibly due to the added noise of the random spikes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "with nengo.Simulator(model) as sim:\n",
+    "    ablate_network(model, 0.25, sim, bias=False)\n",
+    "    sim.run(0.5)\n",
+    "plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To verify that this is indeed working as expected,\n",
+    "we can ablate all of the neurons and confirm that\n",
+    "there is no activity in the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "with nengo.Simulator(model) as sim:\n",
+    "    ablate_network(model, 1, sim)\n",
+    "    sim.run(0.5)\n",
+    "plot()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  },
+  "widgets": {
+   "state": {
+    "00013f0ca1bc40658181b8438fa8cf5e": {
+     "views": []
+    },
+    "01794e20a9cc485b974d27a1d207fa2b": {
+     "views": []
+    },
+    "06e22a5624aa400b841f59826be7ac93": {
+     "views": []
+    },
+    "08f7eb9342ea4ed0b95bbd962cf6985b": {
+     "views": []
+    },
+    "098bf839bf4442f19d0f05423e0da92c": {
+     "views": [
+      {
+       "cell_index": 16
+      }
+     ]
+    },
+    "0c0b025970f344a89f0183770ab8a89f": {
+     "views": []
+    },
+    "0fd020ee43564878aa0e102f7933ba9a": {
+     "views": [
+      {
+       "cell_index": 14
+      }
+     ]
+    },
+    "1018ba8bab444291891da85b4bbb3f85": {
+     "views": []
+    },
+    "136194de0f5e4f92b822821043ac6c24": {
+     "views": []
+    },
+    "1922c4ca3c0e4cbfbac7401a109ccd46": {
+     "views": []
+    },
+    "19fe9288d57946e58a66e542b11de33c": {
+     "views": []
+    },
+    "1bd5e8a952bf443f87c7d7352597416f": {
+     "views": [
+      {
+       "cell_index": 16
+      }
+     ]
+    },
+    "1dcc4b5d12904338845bbda398a0805c": {
+     "views": []
+    },
+    "24b4992658224412ab268fc406d0741d": {
+     "views": [
+      {
+       "cell_index": 8
+      }
+     ]
+    },
+    "2a139eeeee194143ab1741a36e3692c5": {
+     "views": [
+      {
+       "cell_index": 15
+      }
+     ]
+    },
+    "2b0dc0b80b0d488fbaa93553b4fe539e": {
+     "views": [
+      {
+       "cell_index": 16
+      }
+     ]
+    },
+    "2b11df95ba234ee8b63e7a41fed88919": {
+     "views": []
+    },
+    "2b12902053a84f1688c50af9d9d98690": {
+     "views": []
+    },
+    "3352ee992a4440528a481755d8fdbad3": {
+     "views": []
+    },
+    "35a6d22f200848f98aafd7c36b050be0": {
+     "views": [
+      {
+       "cell_index": 14
+      }
+     ]
+    },
+    "36fff258a29e48c4b4db392ade7f8784": {
+     "views": []
+    },
+    "394e7250d24249cd9d360f518f5ca3d5": {
+     "views": [
+      {
+       "cell_index": 3
+      }
+     ]
+    },
+    "3b17ce9db3994654ba61791bfa312ae1": {
+     "views": [
+      {
+       "cell_index": 12
+      }
+     ]
+    },
+    "3d92442d181c4b519357f02db5fb8943": {
+     "views": [
+      {
+       "cell_index": 11
+      }
+     ]
+    },
+    "3e761d874105461c9f8819de431605e3": {
+     "views": []
+    },
+    "407d23c74d514129bc64f2794542cc78": {
+     "views": [
+      {
+       "cell_index": 8
+      }
+     ]
+    },
+    "40a5d5a4cd2044588f2204dd1a3f852d": {
+     "views": [
+      {
+       "cell_index": 16
+      }
+     ]
+    },
+    "46408b8ef39940f6af415dff70ab7dbc": {
+     "views": [
+      {
+       "cell_index": 11
+      }
+     ]
+    },
+    "49afbebd7a234295b3f85988169fc39f": {
+     "views": []
+    },
+    "51203848844a4319a625815ed4a1f805": {
+     "views": []
+    },
+    "5315148967bb4ea49aa08fb54377ddcc": {
+     "views": []
+    },
+    "558b9a55ef3a4642ac28191d941ae389": {
+     "views": []
+    },
+    "63b0d0d6d5dc4575a728d96bc80cdfdf": {
+     "views": [
+      {
+       "cell_index": 14
+      }
+     ]
+    },
+    "67c190e7fe6d45559cb1794b96a9ed82": {
+     "views": [
+      {
+       "cell_index": 14
+      }
+     ]
+    },
+    "7919655309384f17a89e44a852b83d72": {
+     "views": [
+      {
+       "cell_index": 15
+      }
+     ]
+    },
+    "79c0df1a382446ef9d06b3c78e2c7531": {
+     "views": []
+    },
+    "85eed3febe694ea3ad0806e89bc91920": {
+     "views": []
+    },
+    "8976b6c4edc240e2aea67dbc2bd2b3f1": {
+     "views": [
+      {
+       "cell_index": 3
+      }
+     ]
+    },
+    "8d06140aa75f494087ca896a48f40b35": {
+     "views": []
+    },
+    "9503fa7ebf74426284c7a4613518094d": {
+     "views": []
+    },
+    "95399f9749704d5f99ba04f63fa5b1f2": {
+     "views": []
+    },
+    "97d27c09966e43499f9ddfcfa68920d9": {
+     "views": [
+      {
+       "cell_index": 12
+      }
+     ]
+    },
+    "a7908f92e1244f1d850fac1ff3813196": {
+     "views": []
+    },
+    "abe1f008754f4372ba3c93a9daf0d1dd": {
+     "views": []
+    },
+    "ac4cad8ebc30465881953622d59e75bd": {
+     "views": [
+      {
+       "cell_index": 16
+      }
+     ]
+    },
+    "ad86ac7242834c1fada189bcdcd7ac98": {
+     "views": [
+      {
+       "cell_index": 8
+      }
+     ]
+    },
+    "af0f31d0ace44a96a3095d171087cef1": {
+     "views": []
+    },
+    "b114d87d2c254efd886efffe533d5421": {
+     "views": []
+    },
+    "b12b734fd02e43a6a96077edf91a6918": {
+     "views": [
+      {
+       "cell_index": 11
+      }
+     ]
+    },
+    "b29df4a79ad8428a8995203a6edd4d17": {
+     "views": []
+    },
+    "b795904f81144cf59fdc0456bafd213e": {
+     "views": []
+    },
+    "b84ed054ed1a47748e35672867c7a651": {
+     "views": [
+      {
+       "cell_index": 16
+      }
+     ]
+    },
+    "bd905af700a649c792e7555464efc38a": {
+     "views": []
+    },
+    "bea6009e0ecb452497defa49ab31c9fa": {
+     "views": []
+    },
+    "bfe9969bd64b413296159be1fda07b46": {
+     "views": []
+    },
+    "c09cb0a3efcd4d65abc1eccb5e3ea70e": {
+     "views": []
+    },
+    "c39ad9e7d1a24bad8fe41a15608b03aa": {
+     "views": []
+    },
+    "c655fc3b44c24a619a7c347fdddfafc8": {
+     "views": []
+    },
+    "c76bb64489fc4dfda34dd27bda92c33d": {
+     "views": []
+    },
+    "cf419753cb514344af25d8d8f487925f": {
+     "views": []
+    },
+    "d3d17cb909074fd2bbc4860f70f31c3e": {
+     "views": [
+      {
+       "cell_index": 11
+      }
+     ]
+    },
+    "d4cf26823f6846fbb6a092a83ae6832d": {
+     "views": []
+    },
+    "e2b4b552dd124bf3964f14f3680ee4ad": {
+     "views": []
+    },
+    "f1730fae9ab6437fad56cccaac47e9e1": {
+     "views": []
+    },
+    "f6c59c84942a4c348c0f9f92ff27e6c4": {
+     "views": []
+    },
+    "fd48f617336e4007ad0293bcc23839db": {
+     "views": []
+    }
+   },
+   "version": "1.1.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
These examples emulate the ablation of neurons in a brain area by setting their encoders to 0 and their biases to large negative numbers. The unique function here is this:

```python
def ablate_ensemble(ens, proportion, sim):
    """Ablate a proportion of the neurons in an ensemble.

    The ablation is done by setting the encoder and gain associated
    with a neuron to zero. Since no input current being injected,
    the neuron will generally be silent. However, if there is direct
    current injected with a neuron-to-neuron connection, then the
    cell may still fire. To counter that in most cases, we set the
    bias associated with the neuron to a large negative value.
    """

    n_neurons = min(int(ens.n_neurons * proportion), ens.n_neurons)
    idx = np.random.choice(np.arange(ens.n_neurons), replace=False, size=n_neurons)

    encoder_sig = sim.signals[sim.model.sig[ens]['encoders']]
    bias_sig = sim.signals[sim.model.sig[ens.neurons]['bias']]
    encoder_sig.setflags(write=True)
    encoder_sig[idx] = 0.0
    encoder_sig.setflags(write=False)
    bias_sig.setflags(write=True)
    bias_sig[idx] = -1000
```

The two examples here show this used in a simple network (controlled integrator) and a more complex network (SPA sequence).

Note that this requires a slight modification to the builder to expose the bias signal. I'm making a PR to Nengo to expose this now.