### PR TITLE
Point to new Nengo core doc location

### DIFF
--- a/ablate/README.rst
+++ b/ablate/README.rst
@@ -43,7 +43,7 @@ Requirements
 You will need Python installed with the following packages:
 
 - `jupyter <http://jupyter.readthedocs.io/en/latest/install.html>`_
-- `nengo>=2.3.0 <http://pythonhosted.org/nengo/getting_started.html#installation>`_
+- `nengo>=2.3.0 <https://www.nengo.ai/nengo/getting_started.html>`_
 
 Usage
 =====
@@ -58,6 +58,6 @@ License
 
 This example is copyright Applied Brain Research
 and is licensed with the
-`Nengo license <http://pythonhosted.org/nengo/license.html>`_,
+`Nengo license <https://www.nengo.ai/nengo/license.html>`_,
 which permits using, copying, sharing, and making derivative works
 for any non-commercial purpose.

--- a/ablate/ablate_ensemble.ipynb
+++ b/ablate/ablate_ensemble.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "The model used here is a simple controlled integrator,\n",
     "as is shown in\n",
-    "[this core Nengo example](http://pythonhosted.org/nengo/examples/controlled_integrator.html)."
+    "[this core Nengo example](https://www.nengo.ai/nengo/examples/controlled_integrator.html)."
    ]
   },
   {

--- a/ablate/ablate_spa.ipynb
+++ b/ablate/ablate_spa.ipynb
@@ -9,7 +9,7 @@
     "The model used here is a SPA model that goes through\n",
     "a set sequence of semantic pointers,\n",
     "as shown in\n",
-    "[this core Nengo example](http://pythonhosted.org/nengo/examples/controlled_integrator.html).\n",
+    "[this core Nengo example](https://www.nengo.ai/nengo/examples/spa_sequence.html).\n",
     "\n",
     "This is primarily a demonstration of how to apply the `ablate_ensemble` function\n",
     "to all the ensembles in a network or SPA module.\n",

--- a/htbab_tutorials/README.rst
+++ b/htbab_tutorials/README.rst
@@ -19,7 +19,7 @@ Requirements
 You will need Python installed with the following packages:
 
 - `jupyter <http://jupyter.readthedocs.io/en/latest/install.html>`_
-- `nengo <http://pythonhosted.org/nengo/getting_started.html#installation>`_
+- `nengo <https://www.nengo.ai/nengo/getting_started.html>`_
 - `nengo_gui <https://github.com/nengo/nengo_gui#installation>`_
 
 Usage


### PR DESCRIPTION
See https://github.com/nengo/nengo/pull/1338 for details.